### PR TITLE
mkdir: install: Creating /usr/local/[lib bin include] folders during install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,6 +65,7 @@ test: tst/json_string_test tst/generator_test
 	run-parts -v tst
 
 install: $(BINARY) $(DYNAMIC_LIB) $(STATIC_LIB)
+	mkdir -p $(BINDIR) $(LIBDIR) $(INCLUDE)
 	install $(BINARY) $(BINDIR)
 	install $(DYNAMIC_LIB) $(LIBDIR)
 	install $(STATIC_LIB) $(LIBDIR)


### PR DESCRIPTION
Creating /usr/local/[lib bin include] folders before installation else the it could fail
